### PR TITLE
Add quick-start guide to emacs.md

### DIFF
--- a/editors/emacs.md
+++ b/editors/emacs.md
@@ -5,7 +5,11 @@ order: 1
 title: Emacs
 ---
 
-*TODO*: introduction needed here
+ENSIME uses the Scala presentation compiler, a light-weight version of the full compiler that only performs the first few stages of a compilation. It returns syntax/type errors, as well as the type of every expression, in fractions of a second rather than several seconds. This is how you receive instant feedback when you edit a .scala file.
+
+Ensime is available through Melpa. Install it alongside scala-mode2 and add `(add-hook 'scala-mode-hook 'ensime-scala-mode-hook)` to your `.emacs` file. Next, install the [sbt plugin](http://ensime.github.io/build_tools/sbt/) or check [support](http://ensime.github.io/build_tools/) for your built tool of choice. Look [here](http://ensime.github.io/editors/emacs/install/) for more detailed instructions.
+
+Once everything is installed, generate your `.ensime` (`gen-ensime` in sbt), then open emacs and run `M-x ensime`. Edit some code and play around with the commands in the [cheat sheet](http://ensime.github.io/editors/emacs/cheat_sheet/). Good luck!
 
 Some useful resources to learn Emacs:
 


### PR DESCRIPTION
Most people coming to this page are probably experienced users. This change optimizes the emacs front page to give them the info they need to hit the ground running.