### PR TITLE
Fixes for ordering of nav items, rendering of TOCs, and rendering of code blocks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 # Dependencies
-markdown:         redcarpet
-highlighter:      pygments
 
-redcarpet:
-  extensions: ["tables", "autolink", "strikethrough", "space_after_headers", "with_toc_data", "fenced_code_blocks"]
+# We use kramdown for TOC generation.
+# See http://www.seanbuscay.com/blog/jekyll-toc-markdown for details:
+markdown:         kramdown
+highlighter:      pygments
 
 kramdown:
   input: GFM

--- a/_includes/section_nav.html
+++ b/_includes/section_nav.html
@@ -25,7 +25,7 @@ For example, URL containment is a substring check, not a shared prefix check.
 Might cause a bug in the future. Might not. Who knows?
 {% endcomment %}
 
-{% assign site_pages       = site.pages | order:'order' %}
+{% assign site_pages       = site.pages | sort:'order' %}
 {% assign current_page     = include.page %}
 {% assign current_section1 = current_page.url | replace:'/':' ' | truncatewords:1 %}
 {% assign current_section2 = current_page.url | replace:'/':' ' | truncatewords:2 %}

--- a/_includes/site_nav.html
+++ b/_includes/site_nav.html
@@ -8,7 +8,7 @@ We're also working around some limitations in the Liquid language constructs.
 What follows is horrible. Sorry!
 {% endcomment %}
 
-{% assign site_pages      = site.pages | order:'order' %}
+{% assign site_pages      = site.pages | sort:'order' %}
 {% assign current_page    = include.page %}
 {% assign current_section = current_page.url | remove_first:'/' | split:'/' | first %}
 

--- a/editors/emacs/install.md
+++ b/editors/emacs/install.md
@@ -18,7 +18,9 @@ Please help by updating it, moving the non-emacs parts into the their correct ho
 - Scala 2.10 or 2.11.5 or higher
 
 ## Installing ensime-mode for emacs
+
 The recommended way is to use MELPA and to set up a `scala-mode-hook`:
+
 ```elisp
 ;; if you're new to the MELPA package manager, just include
 ;; this entire snippet in your `~/.emacs` file and follow
@@ -38,7 +40,7 @@ The recommended way is to use MELPA and to set up a `scala-mode-hook`:
 ;; (setenv "PATH" (concat "/path/to/sbt/bin:" (getenv "PATH")))
 ;; (setenv "PATH" (concat "/path/to/scala/bin:" (getenv "PATH")))
 ;;
-;; On Macs, it might be a safer bet to use exec-path instead of PATH, for instance: 
+;; On Macs, it might be a safer bet to use exec-path instead of PATH, for instance:
 ;; (setq exec-path (append exec-path '("/usr/local/bin")))
 
 (require 'ensime)
@@ -58,7 +60,9 @@ Much of the actual text editing is provided by the excellent
 be customised.
 
 ### Keeping ensime-mode up-to-date
+
 ENSIME is under active development and there will be from time to time backward-incompatible changes, so it's important to stay up to date. To upgrade all MELPA packages, type:
+
 ```
 M-x list-packages [RETURN] U [RETURN] x [RETURN]
 ```
@@ -106,18 +110,25 @@ The [[Edit Compile Workflow]] is very important to help you to understand why fu
 Emacs-wide customisations are defined in [ensime-vars.el](http://github.com/ensime/ensime-emacs/blob/master/ensime-vars.el) and will appear in `M-x customize`.
 
 # Manual installation
+
 In case the recommended installation method doesn't work for you, or you want to hack on ensime, follow these steps:
+
 ## Installing ensime-mode manually
+
 This is useful if you want to develop ENSIME.
 Clone the github repo:
 
-```git clone https://github.com/ensime/ensime-emacs.git```
+```
+git clone https://github.com/ensime/ensime-emacs.git
+```
 
 into a directory of your choice and add it explicitly into your `~/.emacs`
+
 ```elisp
 ;; assuming you put the repository in ~/.emacs.d/ensime
 (add-to-list 'load-path (concat user-emacs-directory "ensime"))
 ```
+
 Note that you will need to install all the ENSIME dependencies as well. They are listed in the headers of the `ensime.el` file. You can also install ENSIME from source and use MELPA to install the dependencies.
 
 ## Installing the server from assembly builds or source
@@ -139,6 +150,7 @@ cp target/scala-2.10/ensime_2.10-0.9.10-SNAPSHOT-assembly.jar ~/.emacs.d/ensime/
 When you want to swap back to using official releases, delete your `-assembly.jar` files.
 
 ## Installing ensime-sbt from source
+
 ```
 git clone https://github.com/ensime/ensime-sbt.git
 sbt publishLocal
@@ -150,6 +162,7 @@ rm -rf ~/.ivy2/cache/scala_2.10/sbt_0.13/org.ensime # clears official snapshots
 When you want to swap back to using official snapshots, clear out your `~/.ivy2/local`.
 
 # For more information
+
 The ENSIME project is comprised of several github repositories. Follow these links for more information:
 
 - https://github.com/ensime/ensime-server/  (server, main project ; report issues there)


### PR DESCRIPTION
- Fixed ordering of nav items in the site and section navs

- Fixed rendering of inline TOCs by switching back from redcarped to kramdown. Note that this loses us redcarpet's autolinked URL feature :(

- Fixed the rendering of a number of headings and code blocks by adding blank lines to markdown source.
