### PR TITLE
Fix old link; shorten titles for new page layout

### DIFF
--- a/editors/atom/development.md
+++ b/editors/atom/development.md
@@ -1,7 +1,7 @@
 ---
 layout: section
 order: 2
-title: Hacking on Atom Ensime
+title: Developing
 ---
 
 ## Working with the Atom Ensime Source
@@ -27,7 +27,7 @@ title: Hacking on Atom Ensime
 - https://github.com/lukehoban/atom-ide-flow/
 - https://github.com/atom/atom/blob/master/src/text-editor-component.coffee#L365
 - https://github.com/TypeStrong/atom-typescript/
-- https://github.com/chaika2013/ide-haskell/
+- https://github.com/atom-haskell/ide-haskell
 
 ## Useful Links
 

--- a/editors/atom/documentation.md
+++ b/editors/atom/documentation.md
@@ -1,7 +1,7 @@
 ---
 layout: section
 order: 3
-title: Documenting Atom Ensime
+title: Documenting
 ---
 
 ## Improving this documentation

--- a/editors/atom/installation.md
+++ b/editors/atom/installation.md
@@ -1,7 +1,7 @@
 ---
 layout: section
 order: 1
-title: Installing Atom Ensime
+title: Installation
 ---
 
 ## Prerequisites


### PR DESCRIPTION
Fix out-of-date link reported in https://github.com/ensime/ensime-atom/pull/117

The original titles I had wrapped with the new layout. With shorter titles the Atom section now looks like this:

![installation ensime 2016-01-29 12-09-28](https://cloud.githubusercontent.com/assets/102661/12675557/032243b6-c683-11e5-86da-1901c32348bb.png)
