### PR TITLE
Document how to install Gradle plugin per-user

### DIFF
--- a/build_tools/gradle.md
+++ b/build_tools/gradle.md
@@ -10,6 +10,41 @@ Note that this does not support the new [software model](https://docs.gradle.org
 
 The source for this plugin is found in its own GitHub project [ensime/ensime-gradle](https://github.com/ensime/ensime-gradle)
 
+## Install
+The decision to use ENSIME is per-user, rather than per-project. Add the following snippet to your `~/.gradle/init.gradle` file:
+
+```groovy
+apply plugin:AddDepPlugin
+
+class AddDepPlugin  implements Plugin<Gradle> {
+  def addDeps = ["org.ensime.gradle": "gradle.plugin.net.coacoas.gradle:ensime-gradle:0.2.2"]
+  def addRepos = ["https://plugins.gradle.org/m2/"]
+
+  void apply(Gradle gradle) {
+    def add = 0
+    gradle.allprojects { project ->
+      plugins.whenPluginAdded { t ->
+        if (++add == 1) {
+          project.getBuildScriptSource()
+          def bs = project.getBuildscript()
+          bs.getDependencies()
+          def repo = bs.getRepositories()
+          def ccf = bs.class.getDeclaredField("classpathConfiguration")
+          ccf.setAccessible(true)
+          def cc = ccf.get(bs)
+          addDeps.each { k,v-> cc.dependencies.add(project.dependencies.create(v))}
+          addRepos.each { k-> repo.maven { -> setUrl(k) } }
+        }
+        if (add == 8)
+          addDeps.each { k,v ->
+            if (!k.startsWith("x")) project.apply([plugin: k])
+          }
+      }
+    }
+  }
+}
+```
+
 ### Using the plugin in your build
 
 For gradle 2.1+ 


### PR DESCRIPTION
The SBT documentation prefers the installation per-user instead per-project. Although the similar solution for Gradle is not very pretty, it should at least be mentioned by the documentation.