### PR TITLE
Instructions for manually locating SBT in Sublime Text

### DIFF
--- a/editors/sublime/installation.md
+++ b/editors/sublime/installation.md
@@ -34,9 +34,11 @@ Once you have [a `.ensime` file][gen-ensime] for your project, start an ENSIME s
 
 2. Choose *"Ensime: Startup"* from the Sublime Text command palette (*Tools Menu / Command Palette...*).
 
-   If this menu item doesn't appear, check *No Commands in the Command Palette?* in the [Troubleshooting](#troubleshooting) section below.
+   If this menu item doesn't appear, check *No Commands in the Command Palette?* in the [Troubleshooting][troubleshooting] section.
 
 3. The first time you start ENSIME it will take a few minutes to download dependencies and get set up (it'll be much faster on subsequent runs).
+
+   If you get an error message saying Ensime can't find SBT on your PATH, you can manually specify the location in your preferences. Check the [Troubleshooting][troubleshooting] section for details.
 
    *TODO: How do you tell when it's initialised?*
 

--- a/editors/sublime/troubleshooting.md
+++ b/editors/sublime/troubleshooting.md
@@ -8,6 +8,23 @@ title: Troubleshooting
 
 Things go wrong -- we know! Here are some of the main gotchas. If these tips don't solve your problem, [ask on Gitter][gitter] and check the [issue tracker][issues] to see if others have had the same problem.
 
+## Manually Specifying the Location of SBT
+
+If Ensime can't find SBT on your PATH, you can hard-code the location in the preferences for the Sublime Text Ensime package:
+
+- On OS X, choose *Sublime Text Menu / Preferences / Package Settings / Ensime / Settings - User*
+- On Windows and Linux, choose *Preferences Menu / Package Settings / Ensime / Settings - User*
+
+The configuration file will be empty when you open it. Add the path to your SBT executable as follows:
+
+~~~json
+{
+  "sbt_binary": "/path/to/sbt"
+}
+~~~
+
+After that you should be able to run the *Ensime: Startup* command from the Command Palette. If it doesn't work immediately, try restarting Sublime Text.
+
 ## Checking Java and SBT Visiblity
 
 Unsure whether Sublime Text can see Java and SBT on your system application path? Try pasting the following commands one at a time into the Sublime Text console (*View menu / Show Console*).


### PR DESCRIPTION
Based on feedback from Scalasphere.

On OS X, it's far easier to manually configure the location of SBT than alter your path so ENSIME Sublime can find it.
