### PR TITLE
Missed an end quote

### DIFF
--- a/build_tools/gradle.md
+++ b/build_tools/gradle.md
@@ -39,7 +39,7 @@ class AddEnsimePlugin  implements Plugin<Gradle> {
               }
             }
             dependencies {
-              classpath 'net.coacoas.gradle:ensime-gradle:0.2.6
+              classpath 'net.coacoas.gradle:ensime-gradle:0.2.6'
             }
           }
         }


### PR DESCRIPTION
Using the published init script will not work.  There is a quote missing at the end of one line.  This fixes that problem. 