### PR TITLE
Update install.md

### DIFF
--- a/editors/emacs/install.md
+++ b/editors/emacs/install.md
@@ -25,9 +25,7 @@ The recommended way to install ENSIME is via MELPA and registering a `scala-mode
 (use-package ensime
   :commands ensime ensime-mode)
 
-(add-hook 'scala-mode-hook
-    (lambda ()
-        (ensime-mode)))
+(add-hook 'scala-mode-hook 'ensime-mode)
 ```
 
 For the server installation to work, make sure `sbt` is in your `PATH` environment. On OSX, set `exec-path` within Emacs, e.g.:


### PR DESCRIPTION
Adding a lambda directly as a hook can lead to confusion, as modifying the lambda and re-evaluating `add-hook` will not cause the old lambda to removed from the hook (you'll end up with two lambda functions running on scala mode activation).