### PR TITLE
Remove reference to MELPA in the vim troubleshooting section

### DIFF
--- a/editors/vim/troubleshooting.md
+++ b/editors/vim/troubleshooting.md
@@ -14,7 +14,7 @@ Most tickets can be resolved easily by following a simple process.
 1. nuke old versions of the ENSIME server
    - `rm -rf ~/.ivy2/cache/org.ensime`
    - `rm -rf ~/.ivy2/local/org.ensime`
-2. use the latest release of `ensime` for Vim (i.e. update `ensime` via MELPA).
+2. use the latest release of `ensime` for Vim (i.e. update `ensime-vim` via your favorite package manager).
 3. check the [tickets flagged as FAQ for Vim](https://github.com/ensime/ensime-vim/issues?labels=FAQ).
 4. check the [tickets flagged as FAQ on the server](https://github.com/ensime/ensime-server/issues?labels=FAQ).
 5. search for duplicates, especially the [most recently updated tickets](http://github.com/ensime/ensime-vim/issues?direction=desc&sort=updated)


### PR DESCRIPTION
Removed reference to MELPA, because MELPA is an emacs thing.