### PR TITLE
Vim feature matrix correction, minor formatting/spelling

### DIFF
--- a/editors.md
+++ b/editors.md
@@ -16,22 +16,22 @@ The following chart describes how well ENSIME supports each editor:
 | Homepage | [![Emacs](/talks/scalasphere16/images/emacs.svg)](http://www.gnu.org/software/emacs/) | [![Atom](/talks/scalasphere16/images/atom-logo.svg)](https://atom.io/) | [![Vim](/talks/scalasphere16/images/vim-logo.svg)](http://www.vim.org/) | [![VSC](https://upload.wikimedia.org/wikipedia/commons/f/f3/Visual_Studio_Code_0.10.1_icon.png)](https://code.visualstudio.com/) | [![Sublime](/talks/scalasphere16/images/sublime-logo.svg)](https://www.sublimetext.com/) |
 | Main language                         | Emacs Lisp  | Coffeescript | Python | Typescript | Python |
 | Upstream Licence                      | [GPL](http://www.gnu.org/licenses/gpl.en.html) | [MIT](https://opensource.org/licenses/MIT) | [Charityware](http://vimdoc.sourceforge.net/htmldoc/uganda.html#license) | [MIT](https://opensource.org/licenses/MIT) | Proprietary |
-| Type at point                         | ✔ | ✔ | ✔ | | ✔ |
-| Contextual completion                 | ✔ | ✔ | ✔ | | ✔ |
-| Live errors / warnings                | ✔ | ✔ | ✔ | | ✔ |
-| Semantic highlighting                 | ✔ |   | | | |
-| Implicit conversions                  | ✔ | ✔ | ✔ | | |
-| Import class at point                 | ✔ | ✔ | | | ✔ |
-| Classpath search                      | ✔ | ✔ | ✔ | | |
-| Jump to source                        | ✔ | ✔ | ✔ | | ✔ |
-| Show documentation                    | ✔ | ✔ | ✔ | | ✔ |
-| Rename symbol                         | ✔ |   | ✔ | | ✔ |
-| Organise imports                      | ✔ | ✔ | ✔ | | ✔ |
-| Formatting                            | ✔ | ✔ | ✔ | | |
-| Debugging                             | ✔ |   |  | | ✔ |
-| Java Support: ENJIME                  | ✔ |   | | | |
-| REPL                                  | ✔ |   | | | |
-| SBT integration                       | ✔ |   | | | |
+| Type at point                         | ✔ | ✔ | ✔       | | ✔ |
+| Contextual completion                 | ✔ | ✔ | ✔       | | ✔ |
+| Live errors / warnings                | ✔ | ✔ | ✔       | | ✔ |
+| Semantic highlighting                 | ✔ |   |         | | |
+| Implicit conversions                  | ✔ | ✔ |         | | |
+| Import class at point                 | ✔ | ✔ | ✔       | | ✔ |
+| Classpath search                      | ✔ | ✔ | ✔       | | |
+| Jump to source                        | ✔ | ✔ | ✔       | | ✔ |
+| Show documentation                    | ✔ | ✔ | ✔       | | ✔ |
+| Rename symbol                         | ✔ |   | ✔       | | ✔ |
+| Organise imports                      | ✔ | ✔ | ✔       | | ✔ |
+| Formatting                            | ✔ | ✔ | ✔       | | |
+| Debugging                             | ✔ |   | Partial | | ✔ |
+| Java Support: ENJIME                  | ✔ |   |         | | |
+| REPL                                  | ✔ |   |         | | |
+| SBT integration                       | ✔ |   |         | | |
 | [Find usages](https://github.com/ensime/ensime-server/issues/425) | | | | | |
 | [Show implementations](https://github.com/ensime/ensime-server/issues/1131) | | | | | |
 | [Advanced type search](https://github.com/ensime/ensime-server/issues/472) | | | | | |

--- a/editors/vim.md
+++ b/editors/vim.md
@@ -5,9 +5,9 @@ title: Vim
 ---
 
 
-Vim is an extremely configurable/extensible text editor. The ENSIME plugin supports [Vim](http://www.vim.org/) and [NeoVim](https://neovim.io/).
+Vim is an extremely configurable/extensible text editor. The ENSIME plugin supports [Vim](http://www.vim.org/) and [Neovim](https://neovim.io/).
 
-If you're not already familiar with Vim, we recommend going through `:Tutor`, Vim's built-in tutorial.
+If you're not already familiar with Vim, we recommend going through `vimtutor`, Vim's built-in tutorial.
 
 ### Demos
 

--- a/editors/vim/contributing.md
+++ b/editors/vim/contributing.md
@@ -6,7 +6,7 @@ title: Contributing
 
 ## Contributing to the ENSIME-Vim Plugin
 
-First you'll need to for the repository, pull a local copy, add a symlink to your respective plugin directory, and add the necessary `.vimrc`/`init.vim` file.
+First you'll need to pull the repository, add a symlink to the plugin directory used by your respective Vim plugin manager, and add the line to `.vimrc`/`init.vim` to load the plugin if necessary.
 
 Steps:
 
@@ -17,12 +17,12 @@ Steps:
     $ git clone git@github.com:YOURUSER/ensime-vim
     $ git remote add upstream git@github.com:ensime/ensime-vim
     ```
-1. Install your fork of ENSIME-Vim instead of the ensime org's master. For most plugin managers this means replacing the ensime organization's name with your own in the argument to the install function.
-    - If you have already installed ENSIME-VIM you will need to clean your plugins to remove references to the master before installing your fork.
+1. Install your fork of ENSIME-Vim instead of the ensime org's master. For most plugin managers this means replacing the ensime organization's name with your own in the argument to the install function (e.g. `Plugin` for Vundle, `Plug` for vim-plug, `NeoBundle` for neobundle, etc.).
+    - If you have already installed ENSIME-VIM you may need to clean your plugins to remove references to the upstream before installing your fork.
 
 ### Getting Help
 
-The best place for help is the Ensime-Vim Gitter channel. If nobody there can help you, please open an issue on the repository!
+The best place for help is [the ensime-vim Gitter channel][gitter channel]. If nobody there can help you, please open an issue on the repository!
 
 ### Code Organization
 
@@ -30,37 +30,42 @@ ENSIME-Vim is written in a combination of Python and VimL. The VimL code is real
 
 ##### ENSIME integration
 
-- The majority of the interesting code lives in the `ensime_shared` integration. Here you'll find
+- The majority of the interesting code lives in the `ensime_shared` directory. Here you'll find
     - `ensime.py`, which implements all of the request and response handling logic around ENSIME. This is the heart of the plugin.
     - `launcher.py`, which is responsible for starting up ENSIME, loading the config, and generating classpath files
-    - Several other helper files like `config.py`, `error.py`, etc... that each implement small functions dealing with their namesakes
+    - Several other helper files like `config.py`, `error.py`, etc. that each implement small functions dealing with their namesakes
 
 - **Common Tasks**
     - Fixing a bug:
-        First understand if the bug is happening in ENSIME or the Vim plugin. The best way to determine this is to issue a command and compare the input/output of the call in the `.ensime_cache/ensime-vim.log`
+        First understand if the bug is happening in ENSIME or the Vim plugin. The best way to determine this is to issue a command and compare the input/output of the call in the `.ensime_cache/ensime-vim.log` of your project.
          - If the bug is on what we're sending to ENSIME, simply follow the path of the command through the code until you reach the send call. 
-         - For bugs in response handling, you'll want to check the `handlers` dictionary & find the function mapped to the Ensime server response type you're seeing.
+         - For bugs in response handling, you'll want to check the `handlers` dictionary and find the function mapped to the ENSIME server response type you're seeing.
     - Extending an existing Command:
-         - All of the existing commands are defined in `rplugin/python/ensime.py` or `plugin/ensime.vim`, depending on NeoVim or Vim:
-         - Each of the `com_do_something` calls is implemented in the `Ensime` class in `ensime_shared/ensime.py`, which indicates which api handling functions are called
+         - All of the existing commands are defined in `rplugin/python/ensime.py` or `plugin/ensime.vim`, depending on Neovim or Vim:
+         - Each of the `com_do_something` calls is implemented in the `Ensime` class in `ensime_shared/ensime.py`, which indicates which API handling functions are called
          - To change the behavior, you'll likely only need to make changes in the request/response handling code, as the command has already been wired up.
     - Adding a new Command:
         - New ENSIME-Vim commands are a very similar to existing ones, except you're responsible for determining whether it is a standard command or an autocommand. Standard commands are initiated by the user, while autocommands are executed by Vim whenever certain events occur. For a good overview of commands & autocommands I recomend reading Steve Losh's book [Learn VimScript the Hard way](http://learnvimscriptthehardway.stevelosh.com/chapters/12.html)
         - The new command should be added to `plugin/ensime.vim`, `rplugin/python/ensime.py`, `autoload/ensime.vim`, and of course implemented in `ensime_shared/ensime.py`, plus any helper files necessary.
-        - To expose your new command users may need to run `UpdateRemotePlugins`
+        - To expose your new command Neovim users may need to run `:UpdateRemotePlugins`
     - Exposing New Vim Functionality:
         - ENSIME-Vim has a number of Vim commands we execute, all of which can be found in the `commands` dictionary in `ensime_shared/ensime.py`. Adding a new command is as simple as adding a new pair to the dictionary. 
 
-##### Regression Testing
+##### Testing
 
-The tests are currently broken. :-(
+The test suite consists of BDD feature specifications executed with [Lettuce][], a Python framework supporting the Gherkin language. These tests are located in `ensime_shared/spec/features` and can be run with `make test` or simply `make`.
+
+This test suite is relatively young, after dropping old test infrastructure that had fallen into disrepair. Contributions restoring and extending coverage are most welcome. A unit testing setup may be desirable but does not yet exist, it is hoped that some higher-level Gherkin acceptance specs can eventually be shared with other editor plugins.
 
 ##### Useful Links
 
-- [Ensime Contributing]()
-- [Ensime API Source](https://github.com/ensime/ensime-server)
+- [ENSIME Contributing](/contributing/)
+- [ENSIME API Source](https://github.com/ensime/ensime-server)
 - [VimScript The Hard Way](http://learnvimscriptthehardway.stevelosh.com/)
 - Vim Documentation (`:h <your-term-here>`)
 - Other Vim Plugins
     - [NerdTree](https://github.com/scrooloose/nerdtree) Lots of great insights on how to extend Vim's UI
     - [vimmode-python](https://github.com/klen/python-mode) Good for learning about autocomplete, loc vs. qf lists, preview buffers, etc...
+
+[gitter channel]: https://gitter.im/ensime/ensime-vim
+[Lettuce]: http://lettuce.it/

--- a/editors/vim/install.md
+++ b/editors/vim/install.md
@@ -6,20 +6,20 @@ title: Installation
 
 You will need a version of Vim built with Python plugin support. This is standard on most distribution packages these days. Try `vim --version | grep +python` to confirm.
 
-If you're using Ubuntu, as of 16.04, default vim doesn't have python configured. See here for options to get vim with python. http://askubuntu.com/questions/764882/ubuntu-16-04-vim-without-python-support. Note you need python2 support. Make sure pip installs below are for python2 as well (you might need to use pip2).
+If you're using Ubuntu, as of 16.04, default Vim doesn't have Python configured. [See here][python vim ubuntu] for options to get Vim with Python. Note you need **Python 2** support. Make sure pip installs below are for Python 2 as well (you might need to use `pip2`).
 
 1. Install external Python modules that `ensime-vim` requires to function:
 
-    ```bash
+    ```
     $ pip install websocket-client sexpdata
     ```
-1. If you use NeoVim, additionally ensure you've installed the `neovim` module:
+1. If you use Neovim, additionally ensure you've installed the `neovim` module:
 
-   ```bash
+   ```
    $ pip install neovim
    ```
 1. Install the ENSIME plugin for your [build tool](/build_tools)
-1. Add ensime-vim to your plugin manager of choice in your `.vimrc` (or `init.vim` for NeoVim):
+1. Add ensime-vim to your plugin manager of choice in your `.vimrc` (or `init.vim` for Neovim):
 
     Plugin Manager                                    | Your .{n}vimrc
     --------------------------------------------------|-------------------------------
@@ -28,7 +28,7 @@ If you're using Ubuntu, as of 16.04, default vim doesn't have python configured.
     
    Under the hood this is just another Vim plugin, so other plugin managers should work great as well.
 1. Install the [vim-scala] plugin for Scala filetype detection and highlighting. Optionally, install [Syntastic] as well for syntax checking integrated with ENSIME. Instructions for both plugins can be found in their respective documentation.
-1. Trigger the plugin installations after updating your configuration. With `vim-plug` this is done by executing `:PlugInstall`. With `Vundle` run `:PluginInstall`. For NeoVim, you must finally run `:UpdateRemotePlugins` after the installation.
+1. Trigger the plugin installations after updating your configuration. With `vim-plug` this is done by executing `:PlugInstall`. With `Vundle` run `:PluginInstall`. For Neovim, you must finally run `:UpdateRemotePlugins` after the installation.
 
 ##### Post-Install Config
 
@@ -46,12 +46,13 @@ Depending on your preferences, you may want to add some of the following to your
     ```
  - Customize the browser used for `:EnDocBrowse` by setting an environment variable, in your shell initialization
 
-    ```bash
+    ```
     $ export BROWSER="firefox %s"
     ```
 
    By default the plugin tries to make a good guess for your platform (see the Python [webbrowser module] for details). You can also [point the variable to a script][browser-script] for something fancier.
 
+[python vim ubuntu]: http://askubuntu.com/questions/764882/ubuntu-16-04-vim-without-python-support
 [vim-scala]: https://github.com/derekwyatt/vim-scala
 [Syntastic]: https://github.com/scrooloose/syntastic
 [webbrowser module]: https://docs.python.org/2/library/webbrowser.html

--- a/editors/vim/troubleshooting.md
+++ b/editors/vim/troubleshooting.md
@@ -15,7 +15,7 @@ Most tickets can be resolved easily by following a simple process.
    - `rm -rf ~/.ivy2/cache/org.ensime`
    - `rm -rf ~/.ivy2/local/org.ensime`
 2. Use the latest release of `ensime` for Vim (i.e. update `ensime-vim` via your favorite package manager).
-3. Sometimes we update the autocommands for the plugin. This can break NeoVim, so run `:UpdateRemotePlugins` and restart nvim
+3. Sometimes we update the command interface for the plugin. This can break Neovim, so run `:UpdateRemotePlugins` and restart nvim.
 3. Check the [tickets flagged as FAQ for Vim](https://github.com/ensime/ensime-vim/issues?labels=FAQ).
 4. Check the [tickets flagged as FAQ on the server](https://github.com/ensime/ensime-server/issues?labels=FAQ).
 5. Search for duplicates, especially the [most recently updated tickets](http://github.com/ensime/ensime-vim/issues?direction=desc&sort=updated).
@@ -24,7 +24,7 @@ Most tickets can be resolved easily by following a simple process.
 
 ##### I get an error that "`ensime_plugin` is not defined", or there are no `:En*` commands in Vim
 
-If you're using NeoVim, try `:UpdateRemotePlugins`.
+If you're using Neovim, try `:UpdateRemotePlugins`.
 
 If not, or that didn't fix the problem, ensure you installed the Python dependencies:
 
@@ -50,15 +50,15 @@ We recently (Spring 2016) decided that typechecking on write wasn't a sane defau
 au BufWritePost *.scala :EnTypeCheck
 ```
 
-##### The Plugin won't download Ensime
+##### The Plugin won't download ENSIME server
 
-The bootstrapping process can be slow for Ensime, but only needs to be done once per scala-version. To ensure we don't repeat any uncessary work we check for the presence of a classpath-file in `~/.config/ensime/<ScalaVersion>`, where `<ScalaVersion>` is pulled from the `.ensime` config in question. If the classpath file already exist then the ensime jars will not be downloaded. Remove the version directory in question if you want to re-pull the jars (after cleaning your ivy cache of org.ensime of course).
+The bootstrapping process can be slow for ENSIME, but only needs to be done once per Scala version. To ensure we don't repeat any unnecessary work we check for the presence of a classpath-file in `~/.config/ensime/<ScalaVersion>`, where `<ScalaVersion>` is pulled from the `.ensime` config in question. If the classpath file already exist then the `ensime` jars will not be downloaded. Remove the version directory in question if you want to re-pull the jars (after cleaning your Ivy cache of org.ensime of course).
 
 If these solved your problem, great!
 
-If not, please join the conversation on the `gitter.im` room [ensime-vim](https://gitter.im/ensime/ensime-vim). You will benefit by pre-emptively following the steps outlined in the [bug report template](https://github.com/ensime/ensime-vim/blob/master/.github/ISSUE_TEMPLATE.MD).
+If not, please join the conversation on [the ensime-vim Gitter chat](https://gitter.im/ensime/ensime-vim). You will benefit by preemptively following the steps outlined in the [bug report template](https://github.com/ensime/ensime-vim/blob/master/.github/ISSUE_TEMPLATE.MD).
 
-If you think you've found a bug you can file it at [https://github.com/ensime/ensime-vim/issues/new](https://github.com/ensime/ensime-vim/issues/new) (you'd don't need to ask on the channel, just go right ahead and create a ticket).
+If you think you've found a bug you can [file and issue](https://github.com/ensime/ensime-vim/issues/new) (you'd don't need to ask on the channel, just go right ahead and create a ticket).
 
 
 [vim python version]: http://stackoverflow.com/questions/10864042/how-to-check-python-version-that-vim-was-compiled-with

--- a/editors/vim/workflow.md
+++ b/editors/vim/workflow.md
@@ -4,10 +4,10 @@ order: 4
 title: Workflow
 ---
 
-You need to generate a .ensime for your project. See how to do this based on which  [build tool](/build_tools/) you are using . You will need to do this again if you change your project dependancies.
+You need to generate an `.ensime` configuration for your project. See how to do this based on which [build tool](/build_tools/) you are using . You will need to do this again if you change your project dependencies.
 
-Edit a scala file in your project. This will start an ensime server. The first time you run for your project, you will probably need to run ```:EnClasspath``` in vim to generate the classpath for ensime and launch the server.
+Edit a Scala file in your project. This will start an ENSIME server. The first time you run for your project, you will probably need to run `:EnClasspath` in Vim to generate the classpath for ENSIME and launch the server.
 
-You probably want to put your build tool to conitnuously compile so that ensime keeps up to date as you edit your files (```~compile``` in sbt)
+You probably want to set your build tool to continuously compile so that ENSIME keeps up to date as you edit your files (e.g. `~compile` in sbt).
 
-For information on practical ENSIME workflows, you can find some useful information on the [Emacs page](/editors/emacs/userguide)
+For additional practical information on ENSIME workflows, you can find some useful information on the [Emacs page](/editors/emacs/userguide).


### PR DESCRIPTION
The Vim plugin does not support implicit conversion inspections yet, though it does support import suggestions. This may have been a simple mistake of putting the check mark in the adjacent row. We have partial debugger support as well, more underway.

I've included a bunch of minor spelling/grammar/formatting clean-up as well.