### PR TITLE
Update install.md with fix for melpa-stable pinning

### DIFF
--- a/editors/emacs/install.md
+++ b/editors/emacs/install.md
@@ -29,13 +29,18 @@ We assume that you already have [MELPA](http://melpa.org) set up as per our [Lea
 The recommended way to install ENSIME is via MELPA stable and `use-package`:
 
 ```elisp
-(use-package ensime
-  :pin melpa-stable)
+;; Pin ensime to melpa-stable
+(unless (boundp 'package-pinned-packages) (setq package-pinned-packages ()))
+(add-to-list 'package-pinned-packages '(ensime . "melpa-stable"))
+(unless (package-installed-p 'ensime)
+  (package-refresh-contents))
+
+(use-package ensime)
 ```
 
 followed by `M-x package-install ensime`
 
-Do not use `:ensure t` or it will ignore `:pin` and install the unstable version of ensime (not recommended unless you are contributing to ensime).
+To use the unstable version of ENSIME from MELPA comment out the lines before `(use-package ensime)` (not recommended unless you are contributing to ENSIME).
 
 For the server installation to work, make sure `sbt` is on your `PATH` environment variable or `exec-path` Emacs variable, e.g.:
 


### PR DESCRIPTION
Added Ensime pinning to melpa-stable that is compatible with `:ensure t` and `(setq use-package-always-ensure t)`.  Note that package-pinned-packages was introduced in Emacs 24.4.  This variable is also used inside of use-package for its `:pin` implementation, so the Emacs version requirements haven't changed for this to work properly.  The key to making this work was to make sure `(package-refresh-contents)` is called after `package-pinned-packages` is updated.  You can either set `package-pinned-packages` before the first call to `(package-refresh-contents)` in init.el, or you can use the more complicated but self contained logic I've included in this PR.