### PR TITLE
Update Emacs documentation to leverage :ensure and :pin compatibility

### DIFF
--- a/editors/emacs/install.md
+++ b/editors/emacs/install.md
@@ -29,18 +29,13 @@ We assume that you already have [MELPA](http://melpa.org) set up as per our [Lea
 The recommended way to install ENSIME is via MELPA stable and `use-package`:
 
 ```elisp
-;; Pin ensime to melpa-stable
-(unless (boundp 'package-pinned-packages) (setq package-pinned-packages ()))
-(add-to-list 'package-pinned-packages '(ensime . "melpa-stable"))
-(unless (package-installed-p 'ensime)
-  (package-refresh-contents))
-
-(use-package ensime)
+(use-package ensime
+  :pin melpa-stable)
 ```
 
-followed by `M-x package-install ensime`
+If you used the sample Emacs configuration from our [`Learning Emacs`](/editors/emacs/learning) section, then you can add the above code to the end of your `~/.emacs.d/init.el` file and restart Emacs.  Emacs will automatically install Ensime during startup.
 
-To use the unstable version of ENSIME from MELPA comment out the lines before `(use-package ensime)` (not recommended unless you are contributing to ENSIME).
+To use the unstable version of ENSIME from MELPA, remove `:pin melpa-stable` (not recommended unless you are contributing to ENSIME).
 
 For the server installation to work, make sure `sbt` is on your `PATH` environment variable or `exec-path` Emacs variable, e.g.:
 

--- a/editors/emacs/install.md
+++ b/editors/emacs/install.md
@@ -33,7 +33,7 @@ The recommended way to install ENSIME is via MELPA stable and `use-package`:
   :pin melpa-stable)
 ```
 
-If you used the sample Emacs configuration from our [`Learning Emacs`](/editors/emacs/learning) section, then you can add the above code to the end of your `~/.emacs.d/init.el` file and restart Emacs.  Emacs will automatically install Ensime during startup.
+If you used the sample Emacs configuration from our [`Learning Emacs`](/editors/emacs/learning) section, then you can add the above code to the end of your `~/.emacs.d/init.el` file and restart Emacs.  Emacs will automatically install Ensime during startup.  Alternatively, you can execute this without restarting Emacs by moving the cursor ("point" in Emacs nomenclature) to the end of the line and typing `C-x C-e`.
 
 To use the unstable version of ENSIME from MELPA, remove `:pin melpa-stable` (not recommended unless you are contributing to ENSIME).
 

--- a/editors/emacs/learning.md
+++ b/editors/emacs/learning.md
@@ -32,6 +32,7 @@ The following is intended to set some built-in Emacs variables that often confus
  column-number-mode t
  scroll-error-top-bottom t
  show-paren-delay 0.5
+ use-package-always-ensure t
  sentence-end-double-space nil)
 
 ;; buffer local variables
@@ -67,11 +68,10 @@ We recommend [`use-package`](https://github.com/jwiegley/use-package) to manage 
 
 ```elisp
 (use-package evil
-  :ensure t
   :demand)
 ```
 
-you can execute this without restarting Emacs by moving the cursor ("point" in Emacs nomenclature) to the end of the line and typing `C-x C-e`.  `:ensure t` is required to force the package to be automatically downloaded and installed via the package manager.
+you can execute this without restarting Emacs by moving the cursor ("point" in Emacs nomenclature) to the end of the line and typing `C-x C-e`.
 
 
 ## Updating MELPA


### PR DESCRIPTION
I simplified the documentation to take advantage of my fix to use-package that allows  `use-package-always-ensure` to be used with pinning.