### PR TITLE
fix formatting of json block in example settings

### DIFF
--- a/editors/sublime/installation.md
+++ b/editors/sublime/installation.md
@@ -33,17 +33,19 @@ Once you have [a `.ensime` file][ensimeConfig] for your project, start an ENSIME
 1. Open the root folder of your project (the one containing the `.ensime` file) in Sublime Text. If you are already viewing a project file in Sublime, you can open the root folder by selecting *Project Menu / Add Folder to Project...* and selecting the project root directory.
 
 2. Next you need to add SBT to your Sublime path, within Sublime Text, go to the Preferences > Package Settings > Settings > Ensime and select Settings - User to open the Ensime.sublime-settings file. Now add the following to this file.
-   ```json
-   {
-	"sbt_binary": "/path/to/sbt"
-   }
-   ```
+
+~~~json
+{
+  "sbt_binary": "/path/to/sbt"
+}
+~~~
+
 3. [Optional] You may find it helpful to open the console view to see the output and when dependencies are downloaded upon starting Ensime. You do this in the Sublime View menu and selecting Show Console.
 
 4. Choose *"Ensime: Startup"* from the Sublime Text command palette (*Tools Menu / Command Palette...*).
 
    If this menu item doesn't appear, check *No Commands in the Command Palette?* in the [Troubleshooting][troubleshooting] section.
-   
+
 5. The first time you start ENSIME it will take a few minutes to download dependencies and get set up (it'll be much faster on subsequent runs).
 
    If you get an error message saying Ensime can't find SBT on your PATH, you can manually specify the location in your preferences. Check the [Troubleshooting][troubleshooting] section for details.


### PR DESCRIPTION
* The formatting of the example json block is broken when rendered on
  the github pages site:
  http://ensime.github.io/editors/sublime/installation.

  It has an extra "json" element which tripped me up when I was trying
  to get this to work. The block formats correctly on Github.

  This "fix" changes the format to match that on the troubleshooting.md
  page with the same code snippet.