### PR TITLE
Fix link to YAS site

### DIFF
--- a/editors/emacs/hacks.md
+++ b/editors/emacs/hacks.md
@@ -149,7 +149,7 @@ Note that ensime overrides many of these settings in `ensime-company-enable` so 
 
 ### Snippets
 
-[Yet Another Snippet (YAS)](http://capitaomorte.github.io/yasnippet/) provides a wide range of snippets for various languages.
+[Yet Another Snippet (YAS)](https://joaotavora.github.io/yasnippet/) provides a wide range of snippets for various languages.
 
 ```elisp
 (use-package yasnippet


### PR DESCRIPTION
Connects to #66

Unless there's another YAS site that this should be pointing to. Current site is 404