### PR TITLE
Changes `use-package` to actually install ensime

### DIFF
--- a/editors/emacs/install.md
+++ b/editors/emacs/install.md
@@ -30,6 +30,7 @@ The recommended way to install ENSIME is via MELPA stable and `use-package`:
 
 ```elisp
 (use-package ensime
+  :ensure t
   :pin melpa-stable)
 ```
 


### PR DESCRIPTION
Without the `ensure` parameter `use-package` won't install ensime if it isn't already there.