### PR TITLE
Add an example of ensimeLaunch launch configs

### DIFF
--- a/build_tools/sbt.md
+++ b/build_tools/sbt.md
@@ -41,15 +41,36 @@ Note that downloading and resolving the sources and javadocs can take some time 
 
 ## Extra Tasks and Commands
 
-Also bundled are extra workflow tasks, which are used by ensime clients:
+Also bundled are extra workflow tasks, which are used by ENSIME clients:
 
 * `ensimeRunMain` --- alternative to `runMain` allowing environment variables and jvm arguments to be used, e.g. `a/ensimeRunMain FOO=BAR -Xmx2g foo.Bar baz`
-* `c/ensimeLaunch MyApp` --- a launch manager that lets you define pre-canned `ensimeRunMain` applications (analogous to IntelliJ's "Run Configurations")
+* `c/ensimeLaunch MyApp` --- a launch manager that lets you define canned `ensimeRunMain` applications (analogous to IntelliJ's "Run Configurations"---see below)
 * `b/ensimeCompileOnly` --- Compile a single fully qualified `.scala` file using `b`'s classpath. Takes custom flags, e.g. `scalacOptions in (Test, ensimeCompileOnly) ++= Seq("-Xshow-phases")`
 * `b/ensimeScalariformOnly` --- Format a single fully qualified `.scala` file using `b`'s scalariform settings (compatible with, but does not require, `sbt-scalariform`).
 * `ensimeRunDebug` --- like `ensimeRunMain` but adds debugging flags automatically
 * `debugging` / `debuggingOff` --- mutates the default `javaOptions` to include debugging flags (see below)
 
+
+### Launch Configurations
+
+To define presets for the `ensimeLaunch` command, use the `LaunchConfig` and `JavaArgs` case classes provided by sbt-ensime, assigning a sequence to the `ensimeLaunchConfigurations` setting for a project:
+
+```scala
+ensimeLaunchConfigurations := Seq(
+  LaunchConfig("server",
+    JavaArgs(
+      mainClass = "mypackage.Server",
+      classArgs = Seq("start", "--foreground"),
+      envArgs   = Map("MYSERVER_PORT" -> "8080"),
+      jvmArgs   = Seq("-Xmx2g")
+    )
+  )
+)
+```
+
+Invoking `ensimeLaunch server` will then execute the given class with the specified arguments and environment.
+
+An untracked `ensime.sbt` file is [advised](#customise) for this, assuming you have installed sbt-ensime as a global plugin as recommended.
 
 ### Debugging Example
 

--- a/build_tools/sbt.md
+++ b/build_tools/sbt.md
@@ -43,12 +43,13 @@ Note that downloading and resolving the sources and javadocs can take some time 
 
 Also bundled are extra workflow tasks, which are used by ENSIME clients:
 
-* `ensimeRunMain` --- alternative to `runMain` allowing environment variables and jvm arguments to be used, e.g. `a/ensimeRunMain FOO=BAR -Xmx2g foo.Bar baz`
-* `c/ensimeLaunch MyApp` --- a launch manager that lets you define canned `ensimeRunMain` applications (analogous to IntelliJ's "Run Configurations"---see below)
-* `b/ensimeCompileOnly` --- Compile a single fully qualified `.scala` file using `b`'s classpath. Takes custom flags, e.g. `scalacOptions in (Test, ensimeCompileOnly) ++= Seq("-Xshow-phases")`
-* `b/ensimeScalariformOnly` --- Format a single fully qualified `.scala` file using `b`'s scalariform settings (compatible with, but does not require, `sbt-scalariform`).
-* `ensimeRunDebug` --- like `ensimeRunMain` but adds debugging flags automatically
-* `debugging` / `debuggingOff` --- mutates the default `javaOptions` to include debugging flags (see below)
+| `ensimeRunMain`              | Alternative to `runMain` allowing environment variables and jvm arguments to be used, e.g. `a/ensimeRunMain FOO=BAR -Xmx2g foo.Bar baz`. |
+| `c/ensimeLaunch MyApp`       | A launch manager that lets you define canned `ensimeRunMain` applications (analogous to IntelliJ's "Run Configurations"---[see below](#launch-configurations)). |
+| `b/ensimeCompileOnly`        | Compile a single fully-qualified `.scala` file using `b`'s classpath. Takes custom flags, e.g. `scalacOptions in (Test, ensimeCompileOnly) ++= Seq("-Xshow-phases")`. |
+| `b/ensimeScalariformOnly`    | Format a single fully-qualified `.scala` file using `b`'s Scalariform settings (compatible with, but does not require, `sbt-scalariform`). |
+| `ensimeRunDebug`             | Like `ensimeRunMain` but adds debugging flags automatically. |
+| `debugging` / `debuggingOff` | Mutates the default `javaOptions` to include debugging flags ([see below](#debugging-example)). |
+{: .sbt-tasks}
 
 
 ### Launch Configurations

--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -280,6 +280,14 @@ td:nth-child(1), th:nth-child(1) {
     text-align: right;
 }
 
+table.sbt-tasks td {
+    text-align: left;
+    white-space: normal;
+}
+
+table.sbt-tasks td:nth-child(1) {
+    text-align: left;
+}
 
 /*
  * Custom type


### PR DESCRIPTION
I was curious how the new `ensimeLaunch` feature worked and couldn't tell without digging into the source. So, it probably warrants an example. If anything about this isn't reflecting intended usage I'm happy to revise.

Also changed the task listing to a table, much easier to read IMO. A bit hacky to allow per-page styles via `<head>` maybe, but it's an awfully convenient hack 😇   Can probably change this to use classes if desired, I had initially assumed you might avoid changes to CSS files coming from vendor themes but I now see the Git log says otherwise.