### PR TITLE
Updated documentation for ensime-sublime

### DIFF
--- a/editors/sublime.md
+++ b/editors/sublime.md
@@ -16,8 +16,8 @@ ENSIME Sublime is in active development. Supported features include the followin
 - code completion;
 - goto definition;
 - type hints;
-- extract local, extract method;
-- "add-" and "organize imports" functions;
+- inline local;
+- "add import" and "organize imports" functions;
 - support for Scala 2.10 and 2.11.
 
 *ENSIME Sublime is in active development. Watch this page for news and submit issues to our [issue tracker][issues].*

--- a/editors/sublime/configuration.md
+++ b/editors/sublime/configuration.md
@@ -10,12 +10,15 @@ Windows users should ensure the `Line Endings` setting is set to `Unix`. Go to *
 
 ## Mouse Clicks
 
-ENSIME Sublime customizes mouse bindings. It makes `Ctrl+Click`/`Cmd+Click` invoke `Go to Definition` and `Alt+Click` stand for `Inspect Type at Point`.
+ENSIME Sublime customizes mouse bindings. It makes `Ctrl+Click`/`Cmd+Click` invoke `Go to Definition` and `Shift+Click` stand for `Inspect Type at Point`.
 
 These bindings can be altered in the the config: *Preferences Menu / Package Settings / Ensime / Mousemap - Default*.
 
 ## Key Bindings
 
-`Ctrl+Space` invokes code completion by default.
+`Ctrl+Alt+e` invokes `Show errors and warnings` which displays the error and warning messages below the highlighted areas.
+`Ctrl+Alt+i` invokes `Add import`
+`Ctrl+Alt+o` invokes `Organise imports`
+`Ctrl+Space` on Windows/OS X and `Alt+/` on GNU/Linux invokes code completion by default.
 
 Other keybindings can be enabled in the config: *Preferences Menu / Package Settings / Ensime / Keymap - Default*.

--- a/editors/sublime/development.md
+++ b/editors/sublime/development.md
@@ -24,21 +24,6 @@ Rather than installing ENSIME Sublime via Package Control, check out the [Git re
 
 This will Sublime Text to pick up changes in the plugin codebase live as you edit it!
 
-### Additional Configuration
-
-By default, when you run the *Ensime: Startup* command, ENSIME Sublime starts a new instance of ENSIME Server. If you are hacking on ENSIME Server, you may find it useful to disable this behaviour.
-
-To get ENSIME to connect to a pre-existing server instead, go to *Preferences / Package Settings / Ensime / Settings - User* and add the following config entry:
-
-~~~ javascript
-{
-  // other config entries...
-  "connect_to_external_server": false
-}
-~~~
-
-To revert to the default behaviour, set the entry back to `true`.
-
 
 
 [ensime-site]: https://github.com/ensime/ensime.github.io

--- a/editors/sublime/features.md
+++ b/editors/sublime/features.md
@@ -15,11 +15,11 @@ ENSIME enriches your Sublime experience with the following features:
 
 - Right-clicking yields useful context menu items.
 - `Ctrl-Click` or `Cmd-Click` invokes *Go to Definition*.
-- `Alt-Click` invokes *Inspect Type at Point*.
+- `Shift-Click` invokes *Inspect Type at Point*.
 
 ### Keyboard
 
-- Typing `Ctrl-Space` will show an autocomplete menu.
+- Typing `Ctrl-Space` on Windows/OS X and `Alt+/` on GNU/Linux will show an autocomplete menu.
 - Other keybindings can be added [via keymaps][configuration].
 
 ### Command palette

--- a/editors/sublime/installation.md
+++ b/editors/sublime/installation.md
@@ -32,23 +32,11 @@ Once you have [a `.ensime` file][ensimeConfig] for your project, start an ENSIME
 
 1. Open the root folder of your project (the one containing the `.ensime` file) in Sublime Text. If you are already viewing a project file in Sublime, you can open the root folder by selecting *Project Menu / Add Folder to Project...* and selecting the project root directory.
 
-2. Next you need to add sbt to your Sublime path, within Sublime Text, go to the Preferences > Package Settings > Settings > Ensime and select Settings - User to open the Ensime.sublime-settings file. Now add the following to this file.
+2. [Optional] You may find it helpful to open the console view to see the output and logs upon starting Ensime. You do this in the Sublime View menu and selecting Show Console.
 
-~~~json
-{
-  "sbt_binary": "/path/to/sbt"
-}
-~~~
+3. Choose *"Ensime: Startup"* from the Sublime Text command palette (*Tools Menu / Command Palette...*), or simply by selcting *Tools Menu / Ensime / Startup *
 
-3. [Optional] You may find it helpful to open the console view to see the output and when dependencies are downloaded upon starting Ensime. You do this in the Sublime View menu and selecting Show Console.
-
-4. Choose *"Ensime: Startup"* from the Sublime Text command palette (*Tools Menu / Command Palette...*).
-
-   If this menu item doesn't appear, check *No Commands in the Command Palette?* in the [Troubleshooting][troubleshooting] section.
-
-5. The first time you start ENSIME it will take a few minutes to download dependencies and get set up (it'll be much faster on subsequent runs).
-
-   If you get an error message saying Ensime can't find sbt on your PATH, you can manually specify the location in your preferences. Check the [Troubleshooting][troubleshooting] section for details.
+4. The first time you start ENSIME it will take a few minutes to index the files and get set up (it'll be much faster on subsequent runs).
 
    How do you tell when it's initialised?
    Open one of your scala source files and break the code by simply adding a whitespace to a function or class name and then save the file, you will then see the error highlighted within Sublime Text.

--- a/editors/sublime/troubleshooting.md
+++ b/editors/sublime/troubleshooting.md
@@ -8,22 +8,15 @@ title: Troubleshooting
 
 Things go wrong -- we know! Here are some of the main gotchas. If these tips don't solve your problem, [ask on Gitter][gitter] and check the [issue tracker][issues] to see if others have had the same problem.
 
-## Manually Specifying the Location of sbt
+## Let's get this out of the way first
 
-If Ensime can't find sbt on your PATH, you can hard-code the location in the preferences for the Sublime Text Ensime package:
+- Ensure you have created a `.ensime` file using the `ensimeConfig` command.
 
-- On OS X, choose *Sublime Text Menu / Preferences / Package Settings / Ensime / Settings - User*
-- On Windows and Linux, choose *Preferences Menu / Package Settings / Ensime / Settings - User*
+  If you have recently (re)generated your `.ensime` file, you may have to quit and restart Sublime Text to pick up the changes.
 
-The configuration file will be empty when you open it. Add the path to your sbt executable as follows:
+- Ensure the top-most item in the Side Bar (*View Menu / Side Bar / Show Side Bar*) is your project directory (the one containing the `.ensime` file).
 
-~~~json
-{
-  "sbt_binary": "/path/to/sbt"
-}
-~~~
-
-After that you should be able to run the *Ensime: Startup* command from the Command Palette. If it doesn't work immediately, try restarting Sublime Text.
+  If not, choose *Project Menu / Add Folder to Project...* and select the project root directory. You'll be able to continue working in the same file.
 
 
 ## Server out of date
@@ -34,18 +27,15 @@ Nuke old versions of the ENSIME server and try again
 - `rm -rf ~/.ivy2/local/org.ensime`
 
 
-## Checking Java and sbt Visibility
+## Checking Java Visibility
 
-Unsure whether Sublime Text can see Java and sbt on your system application path? Try pasting the following commands one at a time into the Sublime Text console (*View menu / Show Console*).
+Unsure whether Sublime Text can see Java on your system application path? Try pasting the following commands one at a time into the Sublime Text console (*View menu / Show Console*).
 
 On Linux or OS X:
 
 ~~~ python
 # Check the visibility of Java:
 import subprocess; print(subprocess.check_output(['which', 'java'], stderr=subprocess.STDOUT).decode("utf-8"))
-
-# Check the visibility of sbt:
-import subprocess; print(subprocess.check_output(['which', 'sbt'], stderr=subprocess.STDOUT).decode("utf-8"))
 ~~~
 
 On Windows:
@@ -53,9 +43,6 @@ On Windows:
 ~~~ python
 # Check the visibility of Java:
 import subprocess; print(subprocess.check_output(['where', 'java'], stderr=subprocess.STDOUT).decode("utf-8"))
-
-# Check the visibility of sbt:
-import subprocess; print(subprocess.check_output(['where', 'sbt'], stderr=subprocess.STDOUT).decode("utf-8"))
 ~~~
 
 In each case you should see a path string, something like this:
@@ -73,29 +60,21 @@ Traceback (most recent call last):
 subprocess.CalledProcessError: Command '['which', 'java']' returned non-zero exit status 1
 ~~~
 
-## Checking Java and sbt Versions
+## Checking Java Versions
 
-Ideally you should be using Java 8 and sbt 0.13.x. To check this, paste the following commands one at a time into the console (*View Menu / Show Console*):
+Ideally you should be using Java 8. To check this, paste the following commands one at a time into the console (*View Menu / Show Console*):
 
 ~~~ python
 # Check the Java version:
 import subprocess; print(subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT).decode("utf-8"))
-
-# Check the sbt version:
-import subprocess; print(subprocess.check_output(['sbt', 'sbtVersion'], stderr=subprocess.STDOUT).decode("utf-8"))
 ~~~
 
-## No Commands in the Command Palette?
 
-If your command palette doesn't contain the *Ensime: Startup* menu item, it is most likely because ENSIME Sublime can't find your `.ensime` file:
+## None of the commands in the context menu are clickable ?
 
-- Ensure you have created a `.ensime` file using the `ensimeConfig` command.
+If all the commands in the context menu are greyed out, it is most likely because ENSIME is still indexing your files or encountered some error while doing so. Once the indexing is complete you a get a message in the console saying "Indexer is ready! ...". 
 
-  If you have recently (re)generated your `.ensime` file, you may have to quit and restart Sublime Text to pick up the changes.
-
-- Ensure the top-most item in the Side Bar (*View Menu / Side Bar / Show Side Bar*) is your project directory (the one containing the `.ensime` file).
-
-  If not, choose *Project Menu / Add Folder to Project...* and select the project root directory. You'll be able to continue working in the same file.
+If it's been too long and the log files show no indexing messages or any error, deleting the `.ensime_cache` folder in your project directory and restarting ENSIME is worth a try. This will lead to a fresh start and re-index all the files. It only takes a while the first time you Startup ENSIME and is much faster in the subsequent runs.
 
 ## Line Endings
 


### PR DESCRIPTION
- Removed notes on sbt 
- Corrected a few key maps
- Startup is now always visible if the package was installed correctly and shows a message dialog to create .ensime if not there in sublime text itself, hence removed that from troubleshooting
- Added an issue related to context menu that might come up to troubleshooting