### PR TITLE
fixed repository link for VS Code

### DIFF
--- a/editors/vscode.md
+++ b/editors/vscode.md
@@ -12,7 +12,7 @@ This plugin takes the approach of providing a native [Language Server Protocol](
 
 Head over to the repo:
 
-- https://github.com/dragos/dragos-vscode-scala
+- [https://github.com/dragos/dragos-vscode-scala](https://github.com/dragos/dragos-vscode-scala)
 
 to help out!
 


### PR DESCRIPTION
Hi, I've noticed I can't follow the link to dragos-vscode-scala , here's my pr