### PR TITLE
build_tools: Update settings.xml example

### DIFF
--- a/build_tools/maven.md
+++ b/build_tools/maven.md
@@ -17,11 +17,9 @@ This [maven](https://maven.apache.org/) plugin generates a `.ensime` file for us
 Configure your `~/.m2/settings.xml` file so that maven is aware of the plugin group `org.ensime.maven.plugins`:
 
 ```xml
-<build>
-  <pluginGroups>
-    <pluginGroup>org.ensime.maven.plugins</pluginGroup>
-  </pluginGroups>
-</build>
+<pluginGroups>
+  <pluginGroup>org.ensime.maven.plugins</pluginGroup>
+</pluginGroups>
 ```
 
 Or you can add the following to your `pom` file:


### PR DESCRIPTION
There is no <build> tag in maven settings.xml[1], as such remove the tag to ensure that
readers are not mislead by adding a bad tag.

[1] https://maven.apache.org/settings.html